### PR TITLE
Add Cytomining organization GitHub Pages redirects for main organization link and existing projects

### DIFF
--- a/.github/workflows/pre-commit-checks.yaml
+++ b/.github/workflows/pre-commit-checks.yaml
@@ -1,0 +1,16 @@
+# used for running pre-commit checks
+name: pre-commit checks
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+jobs:
+  run_pre_commit_tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - uses: pre-commit/action@v3.0.0

--- a/.htmllintrc
+++ b/.htmllintrc
@@ -1,0 +1,21 @@
+{
+    "tag-bans": [
+        "b",
+        "i"
+    ],
+    "attr-bans": [
+        "align",
+        "background",
+        "bgcolor",
+        "border",
+        "frameborder",
+        "longdesc",
+        "marginwidth",
+        "marginheight",
+        "scrolling",
+        "width"
+    ],
+    "attr-quote-style": false,
+    "indent-width": false,
+    "id-class-style": false
+}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,27 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+---
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-added-large-files
+      - id: detect-private-key
+  # checking spelling
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.2.6
+    hooks:
+      - id: codespell
+  # checking markdown formatting
+  - repo: https://github.com/executablebooks/mdformat
+    rev: 0.7.17
+    hooks:
+      - id: mdformat
+        additional_dependencies:
+          - mdformat-gfm
+  - repo: https://github.com/Lucas-C/pre-commit-hooks-nodejs
+    rev: v1.1.2
+    hooks:
+      - id: htmllint

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2023, cytomining
+Copyright (c) 2023, Cytomining
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
-# cytomining.github.io
-Cytomining organization GitHub Pages configuration.
+# Cytomining organization GitHub Pages configuration
+
+This repo includes content which helps create links via GitHub Pages related to the Cytomining Organization.
+
+## Development
+
+HTML content may be placed within the `/docs` folder which is then rendered on merge to `main`.
+Work here is adapted from [the documentation found in this Gist](https://gist.github.com/domenic/1f286d415559b56d725bee51a62c24a7).

--- a/README.md
+++ b/README.md
@@ -4,5 +4,5 @@ This repo includes content which helps create links via GitHub Pages related to 
 
 ## Development
 
-HTML content may be placed within the `/docs` folder which is then rendered on merge to `main`.
-Work here is adapted from [the documentation found in this Gist](https://gist.github.com/domenic/1f286d415559b56d725bee51a62c24a7).
+You may place HTML content within the `/docs` folder, which is then rendered on merge to `main`.
+We adapt work here from [the documentation found in this Gist](https://gist.github.com/domenic/1f286d415559b56d725bee51a62c24a7).

--- a/docs/cytosnake/index.html
+++ b/docs/cytosnake/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="refresh" content="0; URL=https://cytosnake.readthedocs.io/">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="canonical" href="https://cytosnake.readthedocs.io/">
+    <title>Redirecting to https://cytosnake.readthedocs.io/</title>
+</head>
+<body>
+    Redirecting to <a href="https://cytosnake.readthedocs.io/">https://cytosnake.readthedocs.io/</a>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="refresh" content="0; URL=https://github.com/cytomining">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="canonical" href="https://github.com/cytomining">
+    <title>Redirecting to https://github.com/cytomining</title>
+</head>
+<body>
+    Redirecting to <a href="https://github.com/cytomining">https://github.com/cytomining</a>
+</body>
+</html>

--- a/docs/pycytominer/index.html
+++ b/docs/pycytominer/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="refresh" content="0; URL=https://pycytominer.readthedocs.io/">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="canonical" href="https://pycytominer.readthedocs.io/">
+    <title>Redirecting to https://pycytominer.readthedocs.io/</title>
+</head>
+<body>
+    Redirecting to <a href="https://pycytominer.readthedocs.io/">https://pycytominer.readthedocs.io/</a>
+</body>
+</html>


### PR DESCRIPTION
This PR adds a redirect for https://cytomining.github.io, https://cytomining.github.io/pcytominer, and https://cytomining.github.io/cytosnake by way of GitHub Pages configurations and HTML redirect pages. Linting was also added to help ensure the HTML and spelling are corrected before merging. My understanding is that CytoTable's GitHub pages link will persist as-is, but may need an update here on any changes towards ReadtheDocs, etc.