### PR TITLE
Add CytoTable undercase redirect link

### DIFF
--- a/docs/cytotable/index.html
+++ b/docs/cytotable/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="refresh" content="0; URL=https://cytomining.github.io/CytoTable">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="canonical" href="https://cytomining.github.io/CytoTable">
+    <title>Redirecting to https://cytomining.github.io/CytoTable</title>
+</head>
+<body>
+    Redirecting to <a href="https://cytomining.github.io/CytoTable">https://cytomining.github.io/CytoTable</a>
+</body>
+</html>


### PR DESCRIPTION
This PR adds an undercase CytoTable redirect link as "https://cytomining.github.io/cytotable" to match the other redirect links.